### PR TITLE
$hasError property for transformed fields

### DIFF
--- a/main/common/Form.ts
+++ b/main/common/Form.ts
@@ -1,7 +1,7 @@
 import { computed, reactive, ref, unref } from 'vue';
-import { SimpleRule, Rule } from './composition/useValidation';
-import FormField from './FormField';
-import { PromiseCancel, tryGet, trySet } from './utils';
+import { SimpleRule, Rule } from '../composition/useValidation';
+import { FormField } from './FormField';
+import { PromiseCancel, tryGet, trySet } from '../utils';
 
 type ValidateResult = void | string;
 
@@ -30,7 +30,7 @@ type Keyed = Set<{
 const isSimpleRule = (rule: Rule): rule is SimpleRule =>
   typeof rule === 'function';
 
-export default class Form {
+export class Form {
   private simpleValidators: Map<number, Simple> = new Map();
   private keyedValidators: Map<string, Keyed> = new Map();
 

--- a/main/common/FormField.ts
+++ b/main/common/FormField.ts
@@ -1,9 +1,9 @@
 import { computed, isRef, reactive, ref } from 'vue';
-import { Rule } from './composition/useValidation';
+import { Rule } from '../composition/useValidation';
 
 const notNull = <T>(value: T | null): value is T => value !== null;
 
-export default class FormField {
+export class FormField {
   modelValue: ReturnType<typeof ref> | ReturnType<typeof reactive>;
   touched = false;
   rulesValidating = ref(0);
@@ -36,6 +36,10 @@ export default class FormField {
 
   getErrors() {
     return computed(() => this.errors.filter(notNull));
+  }
+
+  hasError() {
+    return computed(() => this.getErrors().value.length > 0);
   }
 
   validating() {

--- a/main/common/ValidationError.ts
+++ b/main/common/ValidationError.ts
@@ -1,0 +1,5 @@
+export class ValidationError extends Error {
+  constructor() {
+    super('One or more validation errors occurred.');
+  }
+}

--- a/main/common/__tests__/Form.spec.ts
+++ b/main/common/__tests__/Form.spec.ts
@@ -1,5 +1,5 @@
-import FormField from '../FormField';
-import Form from '../Form';
+import { FormField } from '../FormField';
+import { Form } from '../Form';
 import { ref } from 'vue';
 
 let form: Form;

--- a/main/common/__tests__/FormField.spec.ts
+++ b/main/common/__tests__/FormField.spec.ts
@@ -1,4 +1,4 @@
-import FormField from '../FormField';
+import { FormField } from '../FormField';
 
 let formField: FormField;
 

--- a/main/composition/__tests__/useValidation.spec.ts
+++ b/main/composition/__tests__/useValidation.spec.ts
@@ -76,6 +76,7 @@ describe('transform form data', () => {
         $uid: expect.any(Number),
         $value: '',
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -83,6 +84,7 @@ describe('transform form data', () => {
         $uid: expect.any(Number),
         $value: '',
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -90,6 +92,7 @@ describe('transform form data', () => {
         $uid: expect.any(Number),
         $value: [],
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -97,6 +100,7 @@ describe('transform form data', () => {
         $uid: expect.any(Number),
         $value: { a: '' },
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -106,6 +110,7 @@ describe('transform form data', () => {
             $uid: expect.any(Number),
             $value: '',
             $errors: [],
+            $hasError: false,
             $validating: false,
             $onBlur: expect.any(Function)
           },
@@ -116,6 +121,7 @@ describe('transform form data', () => {
             $uid: expect.any(Number),
             $value: '',
             $errors: [],
+            $hasError: false,
             $validating: false,
             $onBlur: expect.any(Function)
           },
@@ -131,6 +137,7 @@ describe('transform form data', () => {
                   }
                 },
                 $errors: [],
+                $hasError: false,
                 $validating: false,
                 $onBlur: expect.any(Function)
               }
@@ -163,6 +170,7 @@ describe('reset fields', () => {
         $uid: expect.any(Number),
         $value: '',
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -170,6 +178,7 @@ describe('reset fields', () => {
         $uid: expect.any(Number),
         $value: '',
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -177,6 +186,7 @@ describe('reset fields', () => {
         $uid: expect.any(Number),
         $value: [],
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -184,6 +194,7 @@ describe('reset fields', () => {
         $uid: expect.any(Number),
         $value: { a: '' },
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -193,6 +204,7 @@ describe('reset fields', () => {
             $uid: expect.any(Number),
             $value: '',
             $errors: [],
+            $hasError: false,
             $validating: false,
             $onBlur: expect.any(Function)
           },
@@ -203,6 +215,7 @@ describe('reset fields', () => {
             $uid: expect.any(Number),
             $value: '',
             $errors: [],
+            $hasError: false,
             $validating: false,
             $onBlur: expect.any(Function)
           },
@@ -218,6 +231,7 @@ describe('reset fields', () => {
                   }
                 },
                 $errors: [],
+                $hasError: false,
                 $validating: false,
                 $onBlur: expect.any(Function)
               }
@@ -262,6 +276,7 @@ describe('reset fields', () => {
         $uid: expect.any(Number),
         $value: 'foo',
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -269,6 +284,7 @@ describe('reset fields', () => {
         $uid: expect.any(Number),
         $value: 'foo',
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -276,6 +292,7 @@ describe('reset fields', () => {
         $uid: expect.any(Number),
         $value: ['foo'],
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -283,6 +300,7 @@ describe('reset fields', () => {
         $uid: expect.any(Number),
         $value: { a: 'foo' },
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -292,6 +310,7 @@ describe('reset fields', () => {
             $uid: expect.any(Number),
             $value: 'foo',
             $errors: [],
+            $hasError: false,
             $validating: false,
             $onBlur: expect.any(Function)
           },
@@ -302,6 +321,7 @@ describe('reset fields', () => {
             $uid: expect.any(Number),
             $value: 'foo',
             $errors: [],
+            $hasError: false,
             $validating: false,
             $onBlur: expect.any(Function)
           },
@@ -317,6 +337,7 @@ describe('reset fields', () => {
                   }
                 },
                 $errors: [],
+                $hasError: false,
                 $validating: false,
                 $onBlur: expect.any(Function)
               }
@@ -417,6 +438,7 @@ describe('add and remove', () => {
         $uid: expect.any(Number),
         $value: '',
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -424,6 +446,7 @@ describe('add and remove', () => {
         $uid: expect.any(Number),
         $value: '',
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -431,6 +454,7 @@ describe('add and remove', () => {
         $uid: expect.any(Number),
         $value: [],
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -438,6 +462,7 @@ describe('add and remove', () => {
         $uid: expect.any(Number),
         $value: { a: '' },
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -447,6 +472,7 @@ describe('add and remove', () => {
             $uid: expect.any(Number),
             $value: '',
             $errors: [],
+            $hasError: false,
             $validating: false,
             $onBlur: expect.any(Function)
           },
@@ -457,6 +483,7 @@ describe('add and remove', () => {
             $uid: expect.any(Number),
             $value: '',
             $errors: [],
+            $hasError: false,
             $validating: false,
             $onBlur: expect.any(Function)
           },
@@ -472,6 +499,7 @@ describe('add and remove', () => {
                   }
                 },
                 $errors: [],
+                $hasError: false,
                 $validating: false,
                 $onBlur: expect.any(Function)
               }
@@ -483,6 +511,7 @@ describe('add and remove', () => {
             $uid: expect.any(Number),
             $value: '',
             $errors: [],
+            $hasError: false,
             $validating: false,
             $onBlur: expect.any(Function)
           },
@@ -504,6 +533,7 @@ describe('add and remove', () => {
         $uid: expect.any(Number),
         $value: '',
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -511,6 +541,7 @@ describe('add and remove', () => {
         $uid: expect.any(Number),
         $value: '',
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -518,6 +549,7 @@ describe('add and remove', () => {
         $uid: expect.any(Number),
         $value: [],
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -525,6 +557,7 @@ describe('add and remove', () => {
         $uid: expect.any(Number),
         $value: { a: '' },
         $errors: [],
+        $hasError: false,
         $validating: false,
         $onBlur: expect.any(Function)
       },
@@ -534,6 +567,7 @@ describe('add and remove', () => {
             $uid: expect.any(Number),
             $value: '',
             $errors: [],
+            $hasError: false,
             $validating: false,
             $onBlur: expect.any(Function)
           },

--- a/main/composition/__tests__/useValidation.spec.ts
+++ b/main/composition/__tests__/useValidation.spec.ts
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import Form from '../../Form';
+import { Form } from '../../common/Form';
 import { cleanupForm } from '../../utils';
 import { Field, useValidation } from '../useValidation';
 

--- a/main/composition/useUid.ts
+++ b/main/composition/useUid.ts
@@ -1,5 +1,5 @@
 let uid = 1;
 
-export default function useUid() {
+export function useUid() {
   return uid++;
 }

--- a/main/index.ts
+++ b/main/index.ts
@@ -1,4 +1,5 @@
 export { useValidation } from './composition/useValidation';
+export { ValidationError } from './common/ValidationError';
 export type {
   Field,
   Rule,

--- a/main/utils/index.ts
+++ b/main/utils/index.ts
@@ -3,3 +3,4 @@ export { tryGet } from './map/tryGet';
 export { path } from './path/path';
 export { PromiseCancel } from './promise-cancel/PromiseCancel';
 export * from './helper/helper';
+export type { RefUnref } from './types/refUnref';

--- a/main/utils/types/refUnref.ts
+++ b/main/utils/types/refUnref.ts
@@ -1,0 +1,19 @@
+import { Ref, UnwrapRef } from 'vue';
+
+type RefUnrefObject<T extends Record<string, unknown>> = {
+  [K in keyof T]: T[K] extends Ref
+    ? T[K] | UnwrapRef<T[K]>
+    : T[K] extends any[]
+    ? T[K]
+    : T[K] extends Record<string, unknown>
+    ? RefUnref<T[K]>
+    : Ref<T[K]> | T[K];
+};
+
+export type RefUnref<T> = T extends Ref
+  ? T | UnwrapRef<T>
+  : T extends any[]
+  ? T
+  : T extends Record<string, unknown>
+  ? RefUnrefObject<T>
+  : Ref<T> | T;

--- a/test-dts/useValidattion.test-d.ts
+++ b/test-dts/useValidattion.test-d.ts
@@ -1,12 +1,12 @@
 import { expectType, expectError } from 'tsd';
 import { ref, Ref } from 'vue';
 import {
-  RefUnref,
   Field,
   Rule,
   TransformedField,
   useValidation
 } from '../main/composition/useValidation';
+import { RefUnref } from '../main/utils';
 
 // ========== RefUnref (RU) ==========
 type RU1 = RefUnref<{ a: string }>;


### PR DESCRIPTION
Added `$hasError` property:
```ts
type TransformedField<T> = {
  $uid: number;
  $value: T;
  $errors: string[];
  $hasError: boolean;
  $validating: boolean;
  $onBlur(): void;
};
```