### PR TITLE
add and remove functions with arbitrary paths

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
   rules: {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
     // https://github.com/typescript-eslint/typescript-eslint/pull/2137
     '@typescript-eslint/ban-types': [
       'error',

--- a/main/common/form-helper/cleanup-form/cleanupForm.ts
+++ b/main/common/form-helper/cleanup-form/cleanupForm.ts
@@ -2,8 +2,13 @@ import { Form } from '../../../form/Form';
 import { deepIterator } from '../../deep-iterator/deepIterator';
 import { isTransformedField } from '../../type-guards/typeGuards';
 
-export function cleanupForm(form: Form, deletedFields: any) {
-  for (const [, value] of deepIterator(deletedFields, isTransformedField)) {
+export function cleanupForm(form: Form, deletedData: any) {
+  if (isTransformedField(deletedData)) {
+    form.onDelete(deletedData.$uid);
+    return;
+  }
+
+  for (const [, value] of deepIterator(deletedData, isTransformedField)) {
     if (isTransformedField(value)) {
       form.onDelete(value.$uid);
     }

--- a/main/common/set/set.ts
+++ b/main/common/set/set.ts
@@ -1,4 +1,4 @@
-export function set(obj: any, keys: (string | number)[], value: any) {
+export function set(obj: any, keys: readonly (string | number)[], value: any) {
   if (keys.length === 0) {
     return;
   }

--- a/main/composition/__tests__/useValidation.spec.ts
+++ b/main/composition/__tests__/useValidation.spec.ts
@@ -1,4 +1,4 @@
-import { Ref, ref } from 'vue';
+import { ref } from 'vue';
 import { Field, TransformedFormData, useValidation } from '../useValidation';
 
 type TestData = {
@@ -12,7 +12,7 @@ type TestData = {
       h: Field<{
         a: {
           b: {
-            c: Ref<number[]>;
+            c: number[];
           };
         };
       }>;
@@ -606,7 +606,7 @@ describe('add and remove', () => {
   test('remove field', () => {
     const { form, remove } = useValidation(testData);
 
-    remove(['es'], 1);
+    remove(['es', 1]);
 
     expect(form).toStrictEqual<typeof form>({
       a: {

--- a/main/composition/useValidation.ts
+++ b/main/composition/useValidation.ts
@@ -44,8 +44,10 @@ export type TransformedFormData<T extends object> = T extends any
 
 export type FormData<T extends object> = T extends any
   ? {
-      [K in keyof T]: T[K] extends { $value: infer TValue }
-        ? UnwrapRef<TValue>
+      [K in keyof T]: T[K] extends Field<infer TValue> | undefined
+        ? T[K] & Field<any> extends Field<any>
+          ? UnwrapRef<TValue>
+          : UnwrapRef<TValue>
         : T[K] extends Record<string, unknown> | any[]
         ? FormData<T[K]>
         : T[K];

--- a/main/composition/useValidation.ts
+++ b/main/composition/useValidation.ts
@@ -2,9 +2,10 @@ import { reactive, Ref, ComputedRef, UnwrapRef } from 'vue';
 import {
   cleanupForm,
   getResultFormData,
-  path,
+  path as _path,
   PromiseCancel,
   resetFields,
+  set,
   transformFormData
 } from '../common';
 import { Form } from '../form/Form';
@@ -31,8 +32,10 @@ export type TransformedField<T> = {
 
 export type TransformedFormData<T extends object> = T extends any
   ? {
-      [K in keyof T]: T[K] extends { $value: infer TValue }
-        ? TransformedField<UnwrapRef<TValue>>
+      [K in keyof T]: T[K] extends Field<infer TValue> | undefined
+        ? T[K] & Field<any> extends Field<any>
+          ? TransformedField<UnwrapRef<TValue>>
+          : TransformedField<UnwrapRef<TValue>>
         : T[K] extends Record<string, unknown> | any[]
         ? TransformedFormData<T[K]>
         : T[K];
@@ -50,15 +53,15 @@ export type FormData<T extends object> = T extends any
   : never;
 
 export type Keys = readonly (string | number)[];
-export type DeepIndex<T, Ks extends Keys> = Ks extends [
+export type DeepIndex<T, Ks extends Keys, R = unknown> = Ks extends [
   infer First,
   ...infer Rest
 ]
   ? First extends keyof T
     ? Rest extends Keys
       ? DeepIndex<T[First], Rest>
-      : undefined
-    : undefined
+      : R
+    : R
   : T;
 
 type UseValidation<T extends object> = {
@@ -68,13 +71,12 @@ type UseValidation<T extends object> = {
   validateFields(): Promise<FormData<T>>;
   resetFields(formData?: Partial<FormData<T>>): void;
   add<Ks extends Keys>(
-    pathToArray: readonly [...Ks],
-    value: DeepIndex<T, Ks> extends Array<infer TArray> ? TArray : never
+    path: readonly [...Ks],
+    value: DeepIndex<T, Ks> extends Array<infer TArray>
+      ? TArray
+      : DeepIndex<T, Ks>
   ): void;
-  remove<Ks extends Keys>(
-    pathToArray: readonly [...Ks],
-    index: DeepIndex<T, Ks> extends any[] ? number : never
-  ): void;
+  remove(path: (string | number)[]): void;
 };
 
 /**
@@ -139,21 +141,35 @@ export function useValidation<T extends object>(formData: T): UseValidation<T> {
       }
     },
 
-    add(pathToArray, value) {
-      const xs = path(pathToArray, transformedFormData);
+    add(path, value) {
+      const box = { value };
+      transformFormData(form, box);
 
-      if (Array.isArray(xs)) {
-        transformFormData(form, value);
-        xs.push(value);
+      const x = _path(path, transformedFormData);
+
+      if (Array.isArray(x)) {
+        x.push(box.value);
+      } else {
+        set(transformedFormData, path, box.value);
       }
     },
 
-    remove(pathToArray, index) {
-      const xs = path(pathToArray, transformedFormData);
+    remove(path) {
+      const lastKey = (path as unknown as any[]).pop();
 
-      if (Array.isArray(xs)) {
-        const deleted = xs.splice(index, 1);
-        deleted.forEach(deleted => cleanupForm(form, deleted));
+      if (typeof lastKey !== 'undefined' && path.length === 0) {
+        cleanupForm(form, (transformedFormData as any)[lastKey]);
+        delete (transformedFormData as any)[lastKey];
+      } else if (typeof lastKey !== 'undefined') {
+        const value = _path(path, transformedFormData);
+
+        if (Array.isArray(value)) {
+          const deleted = value.splice(+lastKey, 1);
+          cleanupForm(form, deleted);
+        } else {
+          cleanupForm(form, value[lastKey]);
+          delete value[lastKey];
+        }
       }
     }
   };

--- a/main/test-dts/useValidattion.test-d.ts
+++ b/main/test-dts/useValidattion.test-d.ts
@@ -34,7 +34,7 @@ useValidation<{ a: Field<{ b: { c: string } }> }>({
   }
 });
 
-// complete example without generic
+// example without generic
 {
   const { form, validateFields, add } = useValidation({
     a: { $value: '' },
@@ -56,7 +56,7 @@ useValidation<{ a: Field<{ b: { c: string } }> }>({
   expectError(add(['cs'], { d: { $value: '' } }));
 }
 
-// complete example with generic
+// example with generic
 {
   const { form, validateFields, add } = useValidation<{
     a: Field<string>;
@@ -140,4 +140,53 @@ useValidation<{ a: Field<{ b: { c: string } }> }>({
       }[];
     }>
   >(validateFields());
+}
+
+// example with optional fields
+{
+  const { form, validateFields, add } = useValidation<{
+    a: Field<string>;
+    b?: Field<boolean>;
+    c?: Field<number>;
+  }>({
+    a: {
+      $value: '',
+      $rules: [x => expect<string>(x)]
+    },
+    b: {
+      $value: false,
+      $rules: [x => expect<boolean>(x)]
+    },
+    c: {
+      $value: 0,
+      $rules: [x => expect<number>(x)]
+    }
+  });
+
+  expectType<{
+    a: TransformedField<string>;
+    b?: TransformedField<boolean>;
+    c?: TransformedField<number>;
+  }>(form);
+
+  expectType<
+    Promise<{
+      a: string;
+      b?: boolean;
+      c?: number;
+    }>
+  >(validateFields());
+
+  expectType<{
+    a: string;
+    b?: boolean;
+    c?: number;
+  }>(await validateFields());
+
+  add(['a'], { $value: '' });
+  add(['b'], { $value: false });
+  add(['c'], { $value: 0 });
+  expectError(add(['a'], { $value: null }));
+  expectError(add(['b'], { $value: null }));
+  expectError(add(['c'], { $value: null }));
 }

--- a/main/test-dts/useValidattion.test-d.ts
+++ b/main/test-dts/useValidattion.test-d.ts
@@ -36,7 +36,7 @@ useValidation<{ a: Field<{ b: { c: string } }> }>({
 
 // complete example without generic
 {
-  const { form, validateFields, add, remove } = useValidation({
+  const { form, validateFields, add } = useValidation({
     a: { $value: '' },
     b: { $value: '' },
     cs: [{ d: { $value: 10 } }]
@@ -54,16 +54,11 @@ useValidation<{ a: Field<{ b: { c: string } }> }>({
 
   add(['cs'], { d: { $value: 10 } });
   expectError(add(['cs'], { d: { $value: '' } }));
-  expectError(add(['cs!'], { d: { $value: 10 } }));
-
-  remove(['cs'], 0);
-  expectError(remove(['cs'], ''));
-  expectError(remove(['cs!'], 0));
 }
 
 // complete example with generic
 {
-  const { form, validateFields, add, remove } = useValidation<{
+  const { form, validateFields, add } = useValidation<{
     a: Field<string>;
     b: Field<string>;
     cs: { d: Field<number> }[];
@@ -98,11 +93,6 @@ useValidation<{ a: Field<{ b: { c: string } }> }>({
 
   add(['cs'], { d: { $value: 10 } });
   expectError(add(['cs'], { d: { $value: '' } }));
-  expectError(add(['cs!'], { d: { $value: 10 } }));
-
-  remove(['cs'], 0);
-  expectError(remove(['cs'], ''));
-  expectError(remove(['cs!'], 0));
 }
 
 {


### PR DESCRIPTION
The `add` and `remove` methods can now take arbitrary paths as arguments and are no longer limited for use with arrays:
```ts
const { form, add, remove } = useValidation({})

type Form = {}

add(['a'], { $value: '' })

type Form = {
  a: TransformedField<string>
}

add(['bs', 0, 'c'], { $value: 0 }) // will create arrays if there are numbers in path

type Form = {
  a: TransformedField<string>,
  bs: [{
    c: TransformedField<number>
  }]
}
```
`remove` no longer needs the second argument `index`:
```ts
remove(['bs', 0])

type Form = {
  a: TransformedField<string>,
  bs: []
}

remove(['a'])

type Form = {
  bs: []
}

remove(['bs'])

type Form = {}
```
fix #2