### PR TITLE
Make sure to throw an `ValidationError` when the form is changed during validation

### DIFF
--- a/packages/vue3-form-validation/__tests__/form/Form.spec.ts
+++ b/packages/vue3-form-validation/__tests__/form/Form.spec.ts
@@ -280,7 +280,7 @@ describe('validation', () => {
     expect(field2.errors.value).toStrictEqual(['rule2'])
   })
 
-  it('`validateAll` should only validate fields with given names and errors should be collected afterwards', async () => {
+  it('`validateAll` should only validate fields with given names and collect errors afterwards', async () => {
     const vbf = jest.fn(() => true)
 
     const rule1 = jest.fn(() => 'rule1')

--- a/packages/vue3-form-validation/__tests__/useValidation.spec.ts
+++ b/packages/vue3-form-validation/__tests__/useValidation.spec.ts
@@ -757,7 +757,7 @@ describe('validation', () => {
     })
   })
 
-  test('changing form values during validation should throw a ValidationError', async () => {
+  test('changing form values during validation should throw an ValidationError', async () => {
     const vbf = jest.fn(() => true)
     const rule = jest.fn((foo: number) => makePromise(50, foo < 5 && 'Error'))
 

--- a/packages/vue3-form-validation/__tests__/useValidation.spec.ts
+++ b/packages/vue3-form-validation/__tests__/useValidation.spec.ts
@@ -756,6 +756,28 @@ describe('validation', () => {
       expect(validating.value).toBe(false)
     })
   })
+
+  test('changing form values during validation should throw a ValidationError', async () => {
+    const vbf = jest.fn(() => true)
+    const rule = jest.fn((foo: number) => makePromise(50, foo < 5 && 'Error'))
+
+    const { form, validateFields } = useValidation({
+      foo: {
+        $value: 0,
+        $rules: [[vbf, rule]]
+      }
+    })
+
+    const promise = validateFields()
+
+    form.foo.$value = 10
+
+    await expect(promise).rejects.toThrow(ValidationError)
+
+    await expect(validateFields()).resolves.toStrictEqual({
+      foo: 10
+    })
+  })
 })
 
 test('add and remove', () => {

--- a/packages/vue3-form-validation/src/form/FormField.ts
+++ b/packages/vue3-form-validation/src/form/FormField.ts
@@ -130,12 +130,12 @@ export class FormField {
         error = await promiseCancel.race(ruleResult)
       } catch (err) {
         if (err instanceof ResetError) {
-          return
+          throw undefined
         }
         if (err instanceof nDomain.CancelError) {
           this.rulesValidating.value--
           this.form.rulesValidating.value--
-          return
+          throw undefined
         }
         error = err
       } finally {


### PR DESCRIPTION
Fixes a bug where the `validateFields` promise would sometimes not throw an error even though the form is invalid.